### PR TITLE
Add make book form view function

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,20 +1,25 @@
 // Create variables targetting the relevant DOM elements here 👇
-var coverImage = document.querySelector('.cover-image')
-var coverTitle = document.querySelector('.cover-title')
-var coverDescriptor = document.querySelector('.tagline')
-var showRandomCover = document.querySelector(`.random-cover-button`)
-
+var coverImage = document.querySelector('.cover-image');
+var coverTitle = document.querySelector('.cover-title');
+var coverDescriptor = document.querySelector('.tagline');
+var showRandomCoverButton = document.querySelector('.random-cover-button');
+var makeOwnCover = document.querySelector('.make-new-button');
+var formView = document.querySelector('.form-view');
+var homeView = document.querySelector('.home-view');
+var saveCoverButton = document.querySelector('.save-cover-button');
+var homeViewButton = document.querySelector('.home-button');
 
 // We've provided a few variables below
 var savedCovers = [
   new Cover("http://3.bp.blogspot.com/-iE4p9grvfpQ/VSfZT0vH2UI/AAAAAAAANq8/wwQZssi-V5g/s1600/Do%2BNot%2BForsake%2BMe%2B-%2BImage.jpg", "Sunsets and Sorrows", "sunsets", "sorrows")
 ];
 var currentCover;
+
 // Add your event listeners here 👇
-showRandomCover.addEventListener('click', displayNewCover);
+showRandomCoverButton.addEventListener('click', displayNewCover);
+makeOwnCover.addEventListener('click', unhideFormView);
 
 // Create your event handlers and other functions here 👇
-
 function getRandomIndex(bookItem) {
   var randomIndex = Math.floor(Math.random() * bookItem.length)
   return bookItem[randomIndex]
@@ -32,6 +37,14 @@ function displayNewCover() {
   coverImage.src = createNewCover().cover
   coverTitle.textContent = createNewCover().title
   coverDescriptor.textContent = `A tale of ${createNewCover().tagline1} and ${createNewCover().tagline2}`
+}
+
+function unhideFormView() {
+  formView.style.display = 'block'
+  homeView.style.display = 'none'
+  showRandomCoverButton.style.display = 'none'
+  saveCoverButton.style.display = 'none'
+  homeViewButton.style.display = 'block'
 }
 
 displayNewCover()


### PR DESCRIPTION
## What is the change? 

Created "Make your own cover" form view. View occurs when clicking "Make your own cover" button on the home page. Form view purposefully hides "Home" and "View saved covers" button

Also some formatting fixes (added semicolons to variable list)

## What does it fix? 

NA

## Is this a fix or a feature?

Feature

## Where should the reviewer start?

Lines 7-10, 20, 42-48

## How should this be tested? 

Open the site (open index) and click the "Make your own cover" button. User should see form view, 'home' and 'View saved covers' are hidden, as well as the random cover that's initially displayed on page load 