### PR TITLE
Various fixes and optimization

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -26,6 +26,7 @@ var savedCovers = [
 ];
 var currentCover;
 var userNewBookCover;
+var homeCurrentCover;
 // var currentCustomCover = [];
 
 // Add your event listeners here 👇
@@ -116,9 +117,6 @@ function createUserNewCover() {
   coverImage.src = userNewBookCover.cover
   coverTitle.textContent = userNewBookCover.title
   coverTagline.textContent = `A tale of ${userNewBookCover.tagline1} and ${userNewBookCover.tagline2}`
-  // if (currentCustomCover === []) {
-  //     currentCustomCover.push(userNewBookCover)
-  // }
 }
 
 function deleteDuplicateCover() {
@@ -137,49 +135,32 @@ function deleteDuplicateCover() {
   }
 }
 
-function createSavedBookCover(index) {
-    var img = document.createElement('IMG');   // CAPITALIZED to invoke
-    img.src = covers[index];
-    var title = document.createElement('H2');
-    title.innerText = ""
-    var descriptor = document.createElement('H3');
-    descriptor.innerText = ""
-    return img;
-}
-
 function loadSavedCovers() {
-  for (i = 0; i < savedCovers.length; i++) {
-    if (savedCovers[i].cover !== createSavedBookCover(i)) {
-      savedCoversSection.appendChild(createSavedBookCover(i)) 
-    }
-  }
+  var miniCoverBlock =
+  `
+  <div class="mini-cover">
+    <img class="mini-cover" src="${homeCurrentCover.cover}">
+    <h2 class="cover-title cover-title::first-letter">${homeCurrentCover.title}</h2>
+    <h3 class="tagline">A tale of ${homeCurrentCover.tagline1} and ${homeCurrentCover.tagline2}</h3>
+  </div>
+  `
+  savedCoversSection.insertAdjacentHTML("afterbegin", miniCoverBlock)
 }
-
-// function loadSavedCovers() {
-//   for (i = 0; i < savedCovers.length; i++) {
-//     if (Object.values(savedCovers[i] === Object.values(createSavedBookCover(i)))) {
-//       savedCoversSection.appendChild(createSavedBookCover(i)) 
-//     }
-//   }
-// }
 
 // saveCurrentCover() for saving current homepage cover into savedCovers array
 // splitTagline() pushed descriptors into array, this fxn uses them and
 // then cleans the array out with .splice()
 function saveCurrentCover() {
   splitTagline()
-  var homeCurrentCover = new Cover(coverImage.src, coverTitle.textContent, taglineArray[0], taglineArray[1])
+  homeCurrentCover = new Cover(coverImage.src, coverTitle.textContent, taglineArray[0], taglineArray[1])
   savedCovers.push(homeCurrentCover)
+  loadSavedCovers()
   return cleanTempArrays()
 }
 
 function cleanTempArrays() {
   taglineArray.splice(0,2)
   // currentCustomCover.splice(0,1)
-}
-
-function testDisplayCovers() {
-  savedCoversSection.appendChild(homeCurrentCover)
 }
 // splitTagline() fxn inside of saveCurrentCover(). split tagline to save desc1 and desc2
 function splitTagline() {
@@ -188,4 +169,3 @@ function splitTagline() {
 }
 
 displayNewCover();
-loadSavedCovers();

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 // Create variables targetting the relevant DOM elements here 👇
 var coverImage = document.querySelector('.cover-image');
 var coverTitle = document.querySelector('.cover-title');
-var coverDescriptor = document.querySelector('.tagline');
+var coverTagline = document.querySelector('.tagline');
 var showRandomCoverButton = document.querySelector('.random-cover-button');
 var makeOwnCover = document.querySelector('.make-new-button');
 var formView = document.querySelector('.form-view');
@@ -16,19 +16,36 @@ var userTitleInput = document.querySelector('#title')
 var userDescriptor1Input = document.querySelector('#descriptor1')
 var userDescriptor2Input = document.querySelector('#descriptor2')
 var userCreateNewCoverButton = document.querySelector('.create-new-book-button')
+
+var savedCoversSection = document.querySelector('.saved-covers-section')
+var taglineArray = []
+
 // We've provided a few variables below
 var savedCovers = [
   new Cover("http://3.bp.blogspot.com/-iE4p9grvfpQ/VSfZT0vH2UI/AAAAAAAANq8/wwQZssi-V5g/s1600/Do%2BNot%2BForsake%2BMe%2B-%2BImage.jpg", "Sunsets and Sorrows", "sunsets", "sorrows")
 ];
 var currentCover;
 var userNewBookCover;
+// var currentCustomCover = [];
 
 // Add your event listeners here 👇
 showRandomCoverButton.addEventListener('click', displayNewCover);
 makeOwnCover.addEventListener('click', unhideFormView);
-savedViewButton.addEventListener('click', unhideSavedView);
+savedViewButton.addEventListener('click',() => {
+  unhideSavedView();
+  // loadSavedCovers();
+});
 homeViewButton.addEventListener('click', unhideHomeView);
-userCreateNewCoverButton.addEventListener('click', saveUserNewCoverData);
+userCreateNewCoverButton.addEventListener('click',() => {
+  saveUserNewCoverData();
+  createUserNewCover();
+  unhideHomeView();
+});
+saveCoverButton.addEventListener('click',() => {
+  saveCurrentCover();
+  deleteDuplicateCover()
+});
+
 // Create your event handlers and other functions here 👇
 function getRandomIndex(bookItem) {
   var randomIndex = Math.floor(Math.random() * bookItem.length)
@@ -49,10 +66,11 @@ function displayNewCover() {
   var newCoverItem = createNewCover()
   coverImage.src = newCoverItem.cover
   coverTitle.textContent = newCoverItem.title
-  coverDescriptor.textContent = `A tale of ${newCoverItem.tagline1} and ${newCoverItem.tagline2}`
+  coverTagline.textContent = `A tale of ${newCoverItem.tagline1} and ${newCoverItem.tagline2}`
 }
 
 function unhideFormView() {
+  savedView.style.display = 'none'
   formView.style.display = 'block'
   homeView.style.display = 'none'
   showRandomCoverButton.style.display = 'none'
@@ -90,17 +108,84 @@ function saveUserNewCoverData() {
   titles.push(userTitleInput.value)
   covers.push(userCoverInput.value)
   descriptors.push(userDescriptor1Input.value, userDescriptor2Input.value)
-  createUserNewCover()
-  unhideHomeView()
   event.preventDefault();
 }
 
 function createUserNewCover() {
-  userNewBookCover = new Cover (covers[covers.length-1], titles[titles.length-1], descriptors[descriptors.length-2], descriptors[descriptors.length-1])
+  userNewBookCover = new Cover(covers[covers.length-1], titles[titles.length-1], descriptors[descriptors.length-2], descriptors[descriptors.length-1])
   coverImage.src = userNewBookCover.cover
   coverTitle.textContent = userNewBookCover.title
-  coverDescriptor.textContent = `A tale of ${userNewBookCover.tagline1} and ${userNewBookCover.tagline2}`
-  return userNewBookCover
+  coverTagline.textContent = `A tale of ${userNewBookCover.tagline1} and ${userNewBookCover.tagline2}`
+  // if (currentCustomCover === []) {
+  //     currentCustomCover.push(userNewBookCover)
+  // }
 }
 
-displayNewCover()
+function deleteDuplicateCover() {
+  var workingEmptyArray = []
+  for (i = 0; i < savedCovers.length - 1; i++) {
+    var bookValues = Object.values(savedCovers[i])
+    var newBookValues = Object.values(savedCovers[savedCovers.length - 1])
+    for (j = 1; j < bookValues.length; j++) {
+      if (bookValues[j] === newBookValues[j]) {
+        workingEmptyArray.push(bookValues[j])
+      }
+    }
+  }
+  if (workingEmptyArray.length === 4) {
+    savedCovers.pop()
+  }
+}
+
+function createSavedBookCover(index) {
+    var img = document.createElement('IMG');   // CAPITALIZED to invoke
+    img.src = covers[index];
+    var title = document.createElement('H2');
+    title.innerText = ""
+    var descriptor = document.createElement('H3');
+    descriptor.innerText = ""
+    return img;
+}
+
+function loadSavedCovers() {
+  for (i = 0; i < savedCovers.length; i++) {
+    if (savedCovers[i].cover !== createSavedBookCover(i)) {
+      savedCoversSection.appendChild(createSavedBookCover(i)) 
+    }
+  }
+}
+
+// function loadSavedCovers() {
+//   for (i = 0; i < savedCovers.length; i++) {
+//     if (Object.values(savedCovers[i] === Object.values(createSavedBookCover(i)))) {
+//       savedCoversSection.appendChild(createSavedBookCover(i)) 
+//     }
+//   }
+// }
+
+// saveCurrentCover() for saving current homepage cover into savedCovers array
+// splitTagline() pushed descriptors into array, this fxn uses them and
+// then cleans the array out with .splice()
+function saveCurrentCover() {
+  splitTagline()
+  var homeCurrentCover = new Cover(coverImage.src, coverTitle.textContent, taglineArray[0], taglineArray[1])
+  savedCovers.push(homeCurrentCover)
+  return cleanTempArrays()
+}
+
+function cleanTempArrays() {
+  taglineArray.splice(0,2)
+  // currentCustomCover.splice(0,1)
+}
+
+function testDisplayCovers() {
+  savedCoversSection.appendChild(homeCurrentCover)
+}
+// splitTagline() fxn inside of saveCurrentCover(). split tagline to save desc1 and desc2
+function splitTagline() {
+  var taglineWordCount = coverTagline.textContent.split(" ")
+  return taglineArray.push(taglineWordCount[3], taglineWordCount[5])
+}
+
+displayNewCover();
+loadSavedCovers();


### PR DESCRIPTION
## What is the change?

- saved covers now display in saved cover section
- number of bug fixes
- clean up code

## What does it fix?

see below in BUGS

## Is this a fix or a feature? 

**FEATURE** 
display saved covers in view saved covers section

**FIXES/CHANGES**
I found a bug that after creating a custom cover using the forms, clicking save cover on the homepage would suddenly stop checking for duplicates and begin saving the same cover to savedCovers array. I fixed it (details at bottom of PR w/previous and current behavior)

The problem is, I think, that we are nesting several functions within functions. There was a conflict with how one of these ested functions were working. INSTEAD of nesting fxn inside of fxn, I nested the required fxn(s) inside of the event listener.  I think this is a good idea because:
- less chance of conflicts
- more readable
- code is more dry

added a line of code at line 74 to prevent cover image from showing on form view when navigating there from saved covers view.

## Where should the reviewer start?

rename var: 4
new vars: 20, 21, 29
listeners: 35-38, 30-39
functions: 138-168
other: 74

## How should this be tested?

Should be no problems navigating between pages - any page to any page. Test by generating random covers and clicking save cover after each random cover is displayed. Try several times. After that click view saved covers to see a list of the covers saved in the previous step. 

## Foreseeable issues

While there are no duplicates in the savedCovers array, currently duplicates do show up on the saved cover page. This is because those saved covers are not pulling from the savedCovers array, but instead are created on 'click' of the 'save cover' button. We will need to think of a way to fix that.

## **On click of  'make my book' button:**

**Previous behavior**: saved input fields to respective data arrays
**Updated behavior**: no change

**Previous behavior**: saved new custom Cover object to savedCovers array
**Updated behavior**:  no longer automatically saves to savedCovers array. Reason: the object data being saved to the array was not consistent with formatting of objects in the array (missing datetime, formatting issues with .src). That inconsistency allowed for duplicates when clicking the 'save cover' button on the homepage (adding the cover object again, but this time with datetime and proper img.src formatting). Now the user clicks 'save cover' if they are happy with the appearance of their custom cover - this stores the new currently displayed custom cover data in an appropriately formatted object inside of the savedCovers array!

**Previous behavior**: navigates to homepage
**Updated behavior**:  no change

**Previous behavior**: displays custom cover on homepage
**Updated behavior**: no change