### PR TITLE
Fix generated duplicates on view saved cover page

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -34,7 +34,7 @@ showRandomCoverButton.addEventListener('click', displayNewCover);
 makeOwnCover.addEventListener('click', unhideFormView);
 savedViewButton.addEventListener('click',() => {
   unhideSavedView();
-  // loadSavedCovers();
+  loadSavedCovers();
 });
 homeViewButton.addEventListener('click', unhideHomeView);
 
@@ -138,25 +138,44 @@ function deleteDuplicateCover() {
 }
 
 function loadSavedCovers() {
-  var miniCoverBlock =
-  `
-  <div class="mini-cover">
-    <img class="mini-cover" src="${homeCurrentCover.cover}">
-    <h2 class="cover-title cover-title::first-letter">${homeCurrentCover.title}</h2>
-    <h3 class="tagline">A tale of ${homeCurrentCover.tagline1} and ${homeCurrentCover.tagline2}</h3>
-  </div>
-  `
-  savedCoversSection.insertAdjacentHTML("afterbegin", miniCoverBlock)
+
+  cleanViewCoversPage()
+
+  var coversList = savedCovers.map(function (element) { return element.cover; });
+  var coversTitle = savedCovers.map(function (element) { return element.title; });
+  var coversTagline1 = savedCovers.map(function (element) { return element.tagline1; });
+  var coversTagline2 = savedCovers.map(function (element) { return element.tagline2; });
+
+  for (var l = 0; l < coversList.length; l++){
+    var coverElement = coversList[l]
+    var titleElement = coversTitle[l]
+    var tagline1Element = coversTagline1[l]
+    var tagline2Element = coversTagline2[l]
+
+    var miniCoverBlock =
+    `
+    <div class="mini-cover">
+      <img class="mini-cover" src="${coverElement}">
+      <h2 class="cover-title cover-title::first-letter">${titleElement}</h2>
+      <h3 class="tagline">A tale of ${tagline1Element} and ${tagline2Element}</h3>
+    </div>
+    `
+    savedCoversSection.insertAdjacentHTML("afterbegin", miniCoverBlock)
+  }
+}
+
+function cleanViewCoversPage() {
+        savedCoversSection.innerHTML = ""
 }
 
 // saveCurrentCover() for saving current homepage cover into savedCovers array
 // splitTagline() pushed descriptors into array, this fxn uses them and
 // then cleans the array out with .splice()
+
 function saveCurrentCover() {
   splitTagline()
   homeCurrentCover = new Cover(coverImage.src, coverTitle.textContent, taglineArray[0], taglineArray[1])
   savedCovers.push(homeCurrentCover)
-  loadSavedCovers()
   return cleanTempArrays()
 }
 
@@ -171,4 +190,3 @@ function splitTagline() {
 }
 
 displayNewCover();
-


### PR DESCRIPTION
## What is the change? 
`loadSavedCovers` function now previews every book cover from the `savedCovers` array. If the View **Saved Covers** button pressed again, it clears the page and loops through `savedCovers `array again to reproduce all covers without duplication. Clearing the page before loading `savedCovers` book covers fixed the bug that generated duplicates by clicking **Save Cover button** several times on the main page. 

## What does it fix?
**Save Cover** button and **View Saved Covers** view. Duplicates are no longer being generated

 ## Is this a fix or a feature?  
Fix

## Where should the reviewer start? 
Line 37 - `loadSavedCovers()` is returned to be called on a clicking event
Line 142 - 153 - created a loop that goes through `savedCovers` array to produce every book cover on the **View Saved Cover** page.
Line 167 - 169 - created a `cleanViewCoversPage() `to reset **View Saved Covers** page every time the **View Saved Covers** button is clicked.

`loadSavedCovers()` was deleted from `saveCurrentCover()` function to avoid duplication of an action.

## How should this be tested?
On the main page `savedCovers` array should be updated with new covers every time we press **Save Cover** button. If we click **View Saved Covers** button we are sent to a **View Covers** page where we will see all our saved covers. By returning to the main page, **Save Cover** button still works and saves only unique covers generated or created by the user.