### PR TITLE
Add double click cover removal feature

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -30,6 +30,7 @@ var userNewBookCover
 var homeCurrentCover
 var taglineArray = []
 var displayViewSettings = {}
+var coverIdNumber = 0
 
 // Add your event listeners here 👇
 showRandomCoverButton.addEventListener('click', displayNewCover)
@@ -164,7 +165,7 @@ function loadSavedCovers() {
   savedCovers.forEach((cover, i) => {
     var miniCoverBlock =
      `
-      <div data-id="${cover.id}" class="mini-cover">
+      <div id="${cover.id}" class="mini-cover">
         <img class="mini-cover" src="${cover.cover}">
         <h2 class="cover-title cover-title::first-letter">${cover.title}</h2>
         <h3 class="tagline">A tale of ${cover.tagline1} and ${cover.tagline2}</h3>
@@ -172,6 +173,23 @@ function loadSavedCovers() {
       `
       savedCoversSection.insertAdjacentHTML("afterbegin", miniCoverBlock)
   })
+  var coversList = document.querySelectorAll(`div.mini-cover`)
+  coversList.forEach((divElement, i) => {
+    divElement.addEventListener('dblclick', () =>  {
+      divElement.remove()
+      coverIdNumber = divElement.id
+      removeCoverFromSavedCovers(coverIdNumber)
+    })
+  })
+}
+
+function removeCoverFromSavedCovers(coverId) {
+  for (var j = 0; j < savedCovers.length; j++){
+    var index = j
+    if (coverId == savedCovers[index].id){
+      savedCovers.splice(index, 1)
+    }
+  }
 }
 
 function cleanViewCoversPage() {


### PR DESCRIPTION
## What is the change? 
Now when user double clicks the cover in a **View Saved Covers** page it removes a saved book from the page and savedCovers array on the background.

## What does it fix? 
N/A

## Is this a fix or a feature? 
Feature

## Where should the reviewer start? 
Line 33 - new variable for cover id
Line 168 - data-id was changed to id
Line 176-192 - new functions and a click event were created

## How should this be tested?
On **View Saved Covers** page double click on any cover will remove the HTML `div.mini-cover` block holding saved cover information and removes `savedCover` object from the array that matches the removed cover from the HTML. As a result the number of objects inside the `savedCovers` array should match the number of covers on the page. 